### PR TITLE
Add pip caching in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.8"
   - "3.9-dev"
   - "nightly"
+cache: pip
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-test.txt


### PR DESCRIPTION
This will hopefully speed things up significantly since the main time suck is building numpy on dev and nightly python versions.